### PR TITLE
Add async person registration endpoints

### DIFF
--- a/ai/turns/3/adr.md
+++ b/ai/turns/3/adr.md
@@ -1,0 +1,15 @@
+# Use WebFlux with in-memory store for person registration
+
+**Status**: Accepted
+
+**Date**: 2025-09-05
+
+**Context**
+The service requires asynchronous CRUD endpoints for person data without a persistent database.
+
+**Decision**
+Use Spring WebFlux with `Mono` types and a concurrent in-memory map to store persons.
+
+**Consequences**
+- Positive: Non-blocking API with minimal infrastructure.
+- Negative: Data is volatile and lost on restart; not suitable for production persistence.

--- a/ai/turns/3/changelog.md
+++ b/ai/turns/3/changelog.md
@@ -1,0 +1,14 @@
+# Turn
+
+### 3  – 2025-09-05T18:22:48Z
+
+## prompt
+Add async person endpoints with in-memory persistence.
+
+#### Task
+Implement asynchronous CRUD endpoints for person domain object and persist in memory.
+
+#### Changes
+- Introduced person domain, service, and controller.
+- Added integration test for person lifecycle.
+- Enabled asynchronous processing in application.

--- a/ai/turns/3/manifest.json
+++ b/ai/turns/3/manifest.json
@@ -1,0 +1,18 @@
+{
+  "turnId": 3,
+  "timestampUtc": "2025-09-05T18:22:48Z",
+  "files": [
+    "src/main/java/com/bobwares/registration/RegistrationApplication.java",
+    "src/main/java/com/bobwares/registration/PersonRequest.java",
+    "src/main/java/com/bobwares/registration/Person.java",
+    "src/main/java/com/bobwares/registration/PersonService.java",
+    "src/main/java/com/bobwares/registration/PersonNotFoundException.java",
+    "src/main/java/com/bobwares/registration/PersonController.java",
+    "src/test/java/com/bobwares/registration/PersonControllerTest.java",
+    "changelog.md",
+    "ai/turns/3/changelog.md",
+    "ai/turns/3/adr.md",
+    "ai/turns/3/manifest.json",
+    "ai/turns/index.csv"
+  ]
+}

--- a/ai/turns/index.csv
+++ b/ai/turns/index.csv
@@ -1,0 +1,2 @@
+turnId,timestampUtc,task,branch,tag,headAfter,testsPassed,testsFailed,coverageDeltaPct
+3,2025-09-05T18:22:48Z,add-person-endpoints,,,,,,

--- a/changelog.md
+++ b/changelog.md
@@ -20,3 +20,12 @@ Update metadata headers and add Makefile
 - Added metadata headers to source, test, and configuration files.
 - Introduced Makefile for build and test commands.
 - Created changelog to track version history.
+
+### 0.0.3 – 2025-09-05 18:22:48 UTC (main)
+
+#### Task
+Add asynchronous person registration endpoints.
+
+#### Changes
+- Added person domain, service, controller, and in-memory persistence.
+- Implemented integration test for person lifecycle.

--- a/src/main/java/com/bobwares/registration/Person.java
+++ b/src/main/java/com/bobwares/registration/Person.java
@@ -1,0 +1,49 @@
+/**
+ * App: common
+ * Package: com.bobwares.registration
+ * File: Person.java
+ * Version: 0.1.0
+ * Turns: 3
+ * Author: AI
+ * Date: 2025-09-05T18:22:48Z
+ * Exports: Person
+ * Description: Domain object representing a registered person with a unique identifier.
+ */
+package com.bobwares.registration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.UUID;
+
+/**
+ * Domain object representing a person.
+ */
+public record Person(
+        @JsonProperty("id") UUID id,
+        @JsonProperty("first_name") String firstName,
+        @JsonProperty("last_name") String lastName,
+        @JsonProperty("city") String city,
+        @JsonProperty("state") String state,
+        @JsonProperty("zip") String zip
+) {
+    /**
+     * Creates a {@link Person} from a {@link PersonRequest} generating a new identifier.
+     *
+     * @param request request data
+     * @return a new person
+     */
+    public static Person from(PersonRequest request) {
+        return new Person(UUID.randomUUID(), request.firstName(), request.lastName(), request.city(), request.state(), request.zip());
+    }
+
+    /**
+     * Creates an updated {@link Person} with a specific identifier.
+     *
+     * @param id      existing identifier
+     * @param request request data
+     * @return updated person
+     */
+    public static Person from(UUID id, PersonRequest request) {
+        return new Person(id, request.firstName(), request.lastName(), request.city(), request.state(), request.zip());
+    }
+}
+

--- a/src/main/java/com/bobwares/registration/PersonController.java
+++ b/src/main/java/com/bobwares/registration/PersonController.java
@@ -1,0 +1,90 @@
+/**
+ * App: common
+ * Package: com.bobwares.registration
+ * File: PersonController.java
+ * Version: 0.1.0
+ * Turns: 3
+ * Author: AI
+ * Date: 2025-09-05T18:22:48Z
+ * Exports: PersonController
+ * Description: REST controller exposing asynchronous CRUD operations for persons.
+ */
+package com.bobwares.registration;
+
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * Asynchronous REST endpoints for person management.
+ */
+@RestController
+@RequestMapping("/api/persons")
+public class PersonController {
+
+    private final PersonService service;
+
+    public PersonController(PersonService service) {
+        this.service = service;
+    }
+
+    /**
+     * Creates a new person.
+     *
+     * @param request request payload
+     * @return created person
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Mono<Person> create(@Validated @RequestBody PersonRequest request) {
+        return service.create(request);
+    }
+
+    /**
+     * Retrieves a person by identifier.
+     *
+     * @param id person identifier
+     * @return requested person
+     */
+    @GetMapping("/{id}")
+    public Mono<Person> get(@PathVariable UUID id) {
+        return service.get(id);
+    }
+
+    /**
+     * Updates a person.
+     *
+     * @param id      identifier
+     * @param request update payload
+     * @return updated person
+     */
+    @PutMapping("/{id}")
+    public Mono<Person> update(@PathVariable UUID id, @Validated @RequestBody PersonRequest request) {
+        return service.update(id, request);
+    }
+
+    /**
+     * Deletes a person.
+     *
+     * @param id identifier
+     * @return completion signal
+     */
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public Mono<Void> delete(@PathVariable UUID id) {
+        return service.delete(id);
+    }
+}
+

--- a/src/main/java/com/bobwares/registration/PersonNotFoundException.java
+++ b/src/main/java/com/bobwares/registration/PersonNotFoundException.java
@@ -1,0 +1,33 @@
+/**
+ * App: common
+ * Package: com.bobwares.registration
+ * File: PersonNotFoundException.java
+ * Version: 0.1.0
+ * Turns: 3
+ * Author: AI
+ * Date: 2025-09-05T18:22:48Z
+ * Exports: PersonNotFoundException
+ * Description: Exception thrown when a person is not found in the in-memory store.
+ */
+package com.bobwares.registration;
+
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Signals that a person could not be located.
+ */
+public class PersonNotFoundException extends ResponseStatusException {
+
+    /**
+     * Creates the exception with a standard message and HTTP 404 status.
+     *
+     * @param id identifier that was not found
+     */
+    public PersonNotFoundException(UUID id) {
+        super(HttpStatus.NOT_FOUND, "Person " + id + " not found");
+    }
+}
+

--- a/src/main/java/com/bobwares/registration/PersonRequest.java
+++ b/src/main/java/com/bobwares/registration/PersonRequest.java
@@ -1,0 +1,43 @@
+/**
+ * App: common
+ * Package: com.bobwares.registration
+ * File: PersonRequest.java
+ * Version: 0.1.0
+ * Turns: 3
+ * Author: AI
+ * Date: 2025-09-05T18:22:48Z
+ * Exports: PersonRequest
+ * Description: Data transfer object representing a request to create or update a person.
+ */
+package com.bobwares.registration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Represents a person creation or update request.
+ * Fields mirror the person.schema.json definition.
+ *
+ * @param firstName person's first name
+ * @param lastName  person's last name
+ * @param city      city of residence
+ * @param state     two-letter state abbreviation
+ * @param zip       ZIP code or ZIP+4
+ */
+public record PersonRequest(
+        @JsonProperty("first_name")
+        @NotBlank(message = "first_name is required") String firstName,
+        @JsonProperty("last_name")
+        @NotBlank(message = "last_name is required") String lastName,
+        @JsonProperty("city")
+        @NotBlank(message = "city is required") String city,
+        @JsonProperty("state")
+        @NotBlank(message = "state is required")
+        @Size(min = 2, max = 2, message = "state must be two letters") String state,
+        @JsonProperty("zip")
+        @NotBlank(message = "zip is required")
+        @Pattern(regexp = "^[0-9]{5}(-[0-9]{4})?$", message = "zip must be 5 digits or ZIP+4") String zip
+) { }
+

--- a/src/main/java/com/bobwares/registration/PersonService.java
+++ b/src/main/java/com/bobwares/registration/PersonService.java
@@ -1,0 +1,78 @@
+/**
+ * App: common
+ * Package: com.bobwares.registration
+ * File: PersonService.java
+ * Version: 0.1.0
+ * Turns: 3
+ * Author: AI
+ * Date: 2025-09-05T18:22:48Z
+ * Exports: PersonService
+ * Description: Service layer managing person persistence in an in-memory store.
+ */
+package com.bobwares.registration;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+/**
+ * Provides CRUD operations for {@link Person} objects using a thread-safe in-memory store.
+ */
+@Service
+public class PersonService {
+
+    private final Map<UUID, Person> store = new ConcurrentHashMap<>();
+
+    /**
+     * Creates and stores a new person.
+     *
+     * @param request person data
+     * @return created person
+     */
+    public Mono<Person> create(PersonRequest request) {
+        Person person = Person.from(request);
+        store.put(person.id(), person);
+        return Mono.just(person);
+    }
+
+    /**
+     * Retrieves a person by identifier.
+     *
+     * @param id person identifier
+     * @return person or error if not found
+     */
+    public Mono<Person> get(UUID id) {
+        return Mono.justOrEmpty(store.get(id))
+                .switchIfEmpty(Mono.error(new PersonNotFoundException(id)));
+    }
+
+    /**
+     * Updates an existing person.
+     *
+     * @param id      identifier
+     * @param request updated data
+     * @return updated person
+     */
+    public Mono<Person> update(UUID id, PersonRequest request) {
+        return get(id).flatMap(existing -> {
+            Person updated = Person.from(id, request);
+            store.put(id, updated);
+            return Mono.just(updated);
+        });
+    }
+
+    /**
+     * Deletes a person by identifier.
+     *
+     * @param id identifier
+     * @return completion signal
+     */
+    public Mono<Void> delete(UUID id) {
+        store.remove(id);
+        return Mono.empty();
+    }
+}
+

--- a/src/main/java/com/bobwares/registration/RegistrationApplication.java
+++ b/src/main/java/com/bobwares/registration/RegistrationApplication.java
@@ -1,0 +1,34 @@
+/**
+ * App: common
+ * Package: com.bobwares.registration
+ * File: RegistrationApplication.java
+ * Version: 0.1.0
+ * Turns: 3
+ * Author: AI
+ * Date: 2025-09-05T18:22:48Z
+ * Exports: RegistrationApplication
+ * Description: Entry point for the Spring Boot application and enables asynchronous processing.
+ */
+package com.bobwares.registration;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+/**
+ * Bootstraps the Spring Boot application.
+ */
+@SpringBootApplication
+@EnableAsync
+public class RegistrationApplication {
+
+    /**
+     * Starts the Spring Boot application.
+     *
+     * @param args runtime arguments
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(RegistrationApplication.class, args);
+    }
+}
+

--- a/src/test/java/com/bobwares/registration/PersonControllerTest.java
+++ b/src/test/java/com/bobwares/registration/PersonControllerTest.java
@@ -1,0 +1,72 @@
+/**
+ * App: common
+ * Package: com.bobwares.registration
+ * File: PersonControllerTest.java
+ * Version: 0.1.0
+ * Turns: 3
+ * Author: AI
+ * Date: 2025-09-05T18:22:48Z
+ * Exports: PersonControllerTest
+ * Description: Integration tests verifying the asynchronous person endpoints.
+ */
+package com.bobwares.registration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+/**
+ * Ensures the person controller supports full CRUD lifecycle.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+class PersonControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private WebTestClient client;
+
+    @Test
+    void createLifecycle() {
+        PersonRequest request = new PersonRequest("John", "Doe", "New York", "NY", "10001");
+
+        String id = client.post().uri("http://localhost:" + port + "/api/persons")
+                .bodyValue(request)
+                .exchange()
+                .expectStatus().isCreated()
+                .expectBody(Person.class)
+                .returnResult()
+                .getResponseBody()
+                .id()
+                .toString();
+
+        client.get().uri("http://localhost:" + port + "/api/persons/{id}", id)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.id").isEqualTo(id);
+
+        PersonRequest update = new PersonRequest("Jane", "Doe", "Los Angeles", "CA", "90001");
+
+        client.put().uri("http://localhost:" + port + "/api/persons/{id}", id)
+                .bodyValue(update)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.first_name").isEqualTo("Jane");
+
+        client.delete().uri("http://localhost:" + port + "/api/persons/{id}", id)
+                .exchange()
+                .expectStatus().isNoContent();
+
+        client.get().uri("http://localhost:" + port + "/api/persons/{id}", id)
+                .exchange()
+                .expectStatus().isNotFound();
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement person domain with validation and snake_case JSON mapping
- expose WebFlux-based CRUD endpoints with in-memory persistence
- add integration test covering full person lifecycle

## Testing
- `mvn test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb29e683bc832d8b745fb2425f9206