### PR TITLE
Implement WebFlux Person CRUD with OpenAPI and tests

### DIFF
--- a/ai/about/version.md
+++ b/ai/about/version.md
@@ -2,3 +2,6 @@
 
 ## 0.1.0
 - Initial proof-of-concept release.
+
+## 0.1.1
+- Implemented WebFlux async CRUD for Person with OpenAPI annotations, unit/integration tests, and E2E .http.

--- a/changelog.md
+++ b/changelog.md
@@ -20,3 +20,15 @@ Update metadata headers and add Makefile
 - Added metadata headers to source, test, and configuration files.
 - Introduced Makefile for build and test commands.
 - Created changelog to track version history.
+
+### 0.0.3 – 2025-09-05 19:46:19 UTC (main)
+
+#### Task
+Implement WebFlux async CRUD for Person
+
+#### Changes
+- Added WebFlux CRUD endpoints, domain records, service, exception, and controller.
+- Added unit and integration tests.
+- Added e2e HTTP scenario for Person.
+- Added OpenAPI dependency for documentation.
+- Updated version history.

--- a/e2e/person.http
+++ b/e2e/person.http
@@ -1,0 +1,46 @@
+# App: common
+# Package: e2e
+# File: person.http
+# Version: 0.1.0
+# Turns: 1
+# Author: Codex Agent
+# Date: 2025-09-05T19:46:19Z
+# Exports: E2E CRUD scenario for Person API
+# Description: Demonstrates create, read, update, delete operations for the Person API using HTTP requests.
+
+@host = http://localhost:8080
+
+### Create person
+POST {{host}}/api/persons
+Content-Type: application/json
+
+{
+  "first_name": "John",
+  "last_name": "Doe",
+  "city": "Boston",
+  "state": "MA",
+  "zip": "02115"
+}
+
+> {% client.global.set("id", response.body.id); %}
+
+### Get person
+GET {{host}}/api/persons/{{id}}
+
+### Update person
+PUT {{host}}/api/persons/{{id}}
+Content-Type: application/json
+
+{
+  "first_name": "Jane",
+  "last_name": "Doe",
+  "city": "Cambridge",
+  "state": "MA",
+  "zip": "02139"
+}
+
+### Delete person
+DELETE {{host}}/api/persons/{{id}}
+
+### Get after delete (expect 404)
+GET {{host}}/api/persons/{{id}}

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,11 @@
             <artifactId>reactor-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webflux-ui</artifactId>
+            <version>2.6.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/bobwares/registration/Person.java
+++ b/src/main/java/com/bobwares/registration/Person.java
@@ -1,0 +1,56 @@
+/**
+ * App: java-spring-boot-codex-starter
+ * Package: com.bobwares.registration
+ * File: Person.java
+ * Version: 0.1.0
+ * Turns: 1
+ * Author: Codex Agent
+ * Date: 2025-09-05T19:46:19Z
+ * Exports: Person
+ * Description: Domain record representing a person with identity and address attributes. Provides factory
+ *              methods for creation and updating based on a {@link PersonRequest}.
+ */
+package com.bobwares.registration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.UUID;
+
+/**
+ * Immutable person domain object.
+ *
+ * @param id unique identifier
+ * @param firstName given name
+ * @param lastName family name
+ * @param city city of residence
+ * @param state two-letter state abbreviation
+ * @param zip postal code
+ */
+public record Person(
+        UUID id,
+        @JsonProperty("first_name") String firstName,
+        @JsonProperty("last_name") String lastName,
+        String city,
+        String state,
+        String zip) {
+
+    /**
+     * Creates a new {@link Person} from a request generating a new identifier.
+     *
+     * @param request validated request payload
+     * @return newly created person
+     */
+    public static Person from(PersonRequest request) {
+        return new Person(UUID.randomUUID(), request.firstName(), request.lastName(), request.city(), request.state(), request.zip());
+    }
+
+    /**
+     * Creates a {@link Person} using an existing identifier and request data.
+     *
+     * @param id existing identifier
+     * @param request validated request payload
+     * @return updated person representation
+     */
+    public static Person from(UUID id, PersonRequest request) {
+        return new Person(id, request.firstName(), request.lastName(), request.city(), request.state(), request.zip());
+    }
+}

--- a/src/main/java/com/bobwares/registration/PersonController.java
+++ b/src/main/java/com/bobwares/registration/PersonController.java
@@ -1,0 +1,126 @@
+/**
+ * App: java-spring-boot-codex-starter
+ * Package: com.bobwares.registration
+ * File: PersonController.java
+ * Version: 0.1.0
+ * Turns: 1
+ * Author: Codex Agent
+ * Date: 2025-09-05T19:46:19Z
+ * Exports: PersonController
+ * Description: Reactive REST controller exposing CRUD endpoints for {@link Person} resources with OpenAPI
+ *              documentation and input validation.
+ */
+package com.bobwares.registration;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+import java.util.UUID;
+
+/**
+ * Handles HTTP requests for person lifecycle operations.
+ */
+@RestController
+@RequestMapping("/api/persons")
+@Tag(name = "Persons", description = "Asynchronous CRUD for persons")
+@Validated
+public class PersonController {
+
+    private final PersonService service;
+
+    /**
+     * Constructs the controller with required dependencies.
+     *
+     * @param service person service
+     */
+    public PersonController(PersonService service) {
+        this.service = service;
+    }
+
+    /**
+     * Creates a new person.
+     *
+     * @param request validated request payload
+     * @return created person
+     */
+    @Operation(summary = "Create person", description = "Creates a new person and returns it")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Person created", content = @Content(schema = @Schema(implementation = Person.class))),
+            @ApiResponse(responseCode = "400", description = "Validation error", content = @Content)
+    })
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Mono<Person> create(@Valid @RequestBody PersonRequest request) {
+        return service.create(request);
+    }
+
+    /**
+     * Retrieves a person by identifier.
+     *
+     * @param id unique identifier
+     * @return found person
+     */
+    @Operation(summary = "Get person", description = "Retrieves a person by id")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Person found", content = @Content(schema = @Schema(implementation = Person.class))),
+            @ApiResponse(responseCode = "404", description = "Person not found", content = @Content)
+    })
+    @GetMapping("/{id}")
+    public Mono<Person> get(@Parameter(description = "Person identifier") @PathVariable UUID id) {
+        return service.get(id);
+    }
+
+    /**
+     * Updates an existing person.
+     *
+     * @param id identifier of the person
+     * @param request validated request payload
+     * @return updated person
+     */
+    @Operation(summary = "Update person", description = "Updates an existing person")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Person updated", content = @Content(schema = @Schema(implementation = Person.class))),
+            @ApiResponse(responseCode = "404", description = "Person not found", content = @Content),
+            @ApiResponse(responseCode = "400", description = "Validation error", content = @Content)
+    })
+    @PutMapping("/{id}")
+    public Mono<Person> update(
+            @Parameter(description = "Person identifier") @PathVariable UUID id,
+            @Valid @RequestBody PersonRequest request) {
+        return service.update(id, request);
+    }
+
+    /**
+     * Deletes a person by identifier.
+     *
+     * @param id identifier of the person
+     * @return completion signal
+     */
+    @Operation(summary = "Delete person", description = "Deletes a person by id")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Person deleted", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Person not found", content = @Content)
+    })
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public Mono<Void> delete(@Parameter(description = "Person identifier") @PathVariable UUID id) {
+        return service.delete(id);
+    }
+}

--- a/src/main/java/com/bobwares/registration/PersonNotFoundException.java
+++ b/src/main/java/com/bobwares/registration/PersonNotFoundException.java
@@ -1,0 +1,32 @@
+/**
+ * App: java-spring-boot-codex-starter
+ * Package: com.bobwares.registration
+ * File: PersonNotFoundException.java
+ * Version: 0.1.0
+ * Turns: 1
+ * Author: Codex Agent
+ * Date: 2025-09-05T19:46:19Z
+ * Exports: PersonNotFoundException
+ * Description: Exception thrown when a requested person cannot be located in the persistence store.
+ */
+package com.bobwares.registration;
+
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Indicates the requested person does not exist.
+ */
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class PersonNotFoundException extends RuntimeException {
+
+    /**
+     * Creates a new exception with a descriptive message for the missing identifier.
+     *
+     * @param id identifier that could not be found
+     */
+    public PersonNotFoundException(UUID id) {
+        super("Person with id " + id + " not found");
+    }
+}

--- a/src/main/java/com/bobwares/registration/PersonRequest.java
+++ b/src/main/java/com/bobwares/registration/PersonRequest.java
@@ -1,0 +1,35 @@
+/**
+ * App: java-spring-boot-codex-starter
+ * Package: com.bobwares.registration
+ * File: PersonRequest.java
+ * Version: 0.1.0
+ * Turns: 1
+ * Author: Codex Agent
+ * Date: 2025-09-05T19:46:19Z
+ * Exports: PersonRequest
+ * Description: Data transfer object capturing input fields for a person with validation constraints applied
+ *              to ensure data integrity.
+ */
+package com.bobwares.registration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Payload representing a person creation or update request.
+ *
+ * @param firstName given name
+ * @param lastName family name
+ * @param city city of residence
+ * @param state two-letter state abbreviation
+ * @param zip postal code in five-digit or ZIP+4 format
+ */
+public record PersonRequest(
+        @JsonProperty("first_name") @NotBlank String firstName,
+        @JsonProperty("last_name") @NotBlank String lastName,
+        @NotBlank String city,
+        @Size(min = 2, max = 2) String state,
+        @Pattern(regexp = "^[0-9]{5}(-[0-9]{4})?$") String zip) {
+}

--- a/src/main/java/com/bobwares/registration/PersonService.java
+++ b/src/main/java/com/bobwares/registration/PersonService.java
@@ -1,0 +1,85 @@
+/**
+ * App: java-spring-boot-codex-starter
+ * Package: com.bobwares.registration
+ * File: PersonService.java
+ * Version: 0.1.0
+ * Turns: 1
+ * Author: Codex Agent
+ * Date: 2025-09-05T19:46:19Z
+ * Exports: PersonService
+ * Description: Application service providing asynchronous CRUD operations backed by an in-memory, thread-safe
+ *              store.
+ */
+package com.bobwares.registration;
+
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import reactor.core.publisher.Mono;
+
+/**
+ * Handles persistence operations for {@link Person} instances using a concurrent map.
+ */
+public class PersonService {
+
+    private final ConcurrentMap<UUID, Person> store = new ConcurrentHashMap<>();
+
+    /**
+     * Creates a new person and stores it.
+     *
+     * @param request validated request payload
+     * @return asynchronous result containing the created person
+     */
+    public Mono<Person> create(PersonRequest request) {
+        Person person = Person.from(request);
+        store.put(person.id(), person);
+        return Mono.just(person);
+    }
+
+    /**
+     * Retrieves a person by identifier.
+     *
+     * @param id identifier of the person
+     * @return asynchronous result containing the person if found
+     * @throws PersonNotFoundException when the id is not present
+     */
+    public Mono<Person> get(UUID id) {
+        Person person = store.get(id);
+        if (person == null) {
+            return Mono.error(new PersonNotFoundException(id));
+        }
+        return Mono.just(person);
+    }
+
+    /**
+     * Updates an existing person with new attributes.
+     *
+     * @param id identifier of the person to update
+     * @param request validated request payload
+     * @return asynchronous result containing the updated person
+     * @throws PersonNotFoundException when the id is not present
+     */
+    public Mono<Person> update(UUID id, PersonRequest request) {
+        if (!store.containsKey(id)) {
+            return Mono.error(new PersonNotFoundException(id));
+        }
+        Person person = Person.from(id, request);
+        store.put(id, person);
+        return Mono.just(person);
+    }
+
+    /**
+     * Deletes a person by identifier.
+     *
+     * @param id identifier of the person to remove
+     * @return completion signal when deletion is finished
+     * @throws PersonNotFoundException when the id is not present
+     */
+    public Mono<Void> delete(UUID id) {
+        Person removed = store.remove(id);
+        if (removed == null) {
+            return Mono.error(new PersonNotFoundException(id));
+        }
+        return Mono.empty();
+    }
+}

--- a/src/main/java/com/bobwares/registration/RegistrationApplication.java
+++ b/src/main/java/com/bobwares/registration/RegistrationApplication.java
@@ -1,0 +1,31 @@
+/**
+ * App: java-spring-boot-codex-starter
+ * Package: com.bobwares.registration
+ * File: RegistrationApplication.java
+ * Version: 0.1.0
+ * Turns: 1
+ * Author: Codex Agent
+ * Date: 2025-09-05T19:46:19Z
+ * Exports: RegistrationApplication
+ * Description: Boots the Spring Boot WebFlux application and provides the main entry point.
+ */
+package com.bobwares.registration;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Entry point for the WebFlux registration service.
+ */
+@SpringBootApplication
+public class RegistrationApplication {
+
+    /**
+     * Starts the Spring Boot application.
+     *
+     * @param args command-line arguments
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(RegistrationApplication.class, args);
+    }
+}

--- a/src/test/java/com/bobwares/registration/PersonControllerIT.java
+++ b/src/test/java/com/bobwares/registration/PersonControllerIT.java
@@ -1,0 +1,73 @@
+/**
+ * App: java-spring-boot-codex-starter
+ * Package: com.bobwares.registration
+ * File: PersonControllerIT.java
+ * Version: 0.1.0
+ * Turns: 1
+ * Author: Codex Agent
+ * Date: 2025-09-05T19:46:19Z
+ * Exports: PersonControllerIT
+ * Description: Integration tests validating the HTTP endpoints exposed by {@link PersonController} using
+ *              WebTestClient against a running application context.
+ */
+package com.bobwares.registration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+/**
+ * Exercises the REST API end-to-end.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+public class PersonControllerIT {
+
+    @Autowired
+    private WebTestClient client;
+
+    /**
+     * Verifies the full CRUD lifecycle through HTTP requests.
+     */
+    @Test
+    void personLifecycle() {
+        PersonRequest request = new PersonRequest("John", "Doe", "Boston", "MA", "02115");
+
+        String id = client.post().uri("/api/persons")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(request)
+                .exchange()
+                .expectStatus().isCreated()
+                .expectBody(Person.class)
+                .returnResult()
+                .getResponseBody()
+                .id()
+                .toString();
+
+        client.get().uri("/api/persons/{id}", id)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.first_name").isEqualTo("John");
+
+        PersonRequest update = new PersonRequest("Jane", "Doe", "Cambridge", "MA", "02139");
+        client.put().uri("/api/persons/{id}", id)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(update)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.first_name").isEqualTo("Jane");
+
+        client.delete().uri("/api/persons/{id}", id)
+                .exchange()
+                .expectStatus().isNoContent();
+
+        client.get().uri("/api/persons/{id}", id)
+                .exchange()
+                .expectStatus().isNotFound();
+    }
+}

--- a/src/test/java/com/bobwares/registration/PersonServiceTests.java
+++ b/src/test/java/com/bobwares/registration/PersonServiceTests.java
@@ -1,0 +1,46 @@
+/**
+ * App: java-spring-boot-codex-starter
+ * Package: com.bobwares.registration
+ * File: PersonServiceTests.java
+ * Version: 0.1.0
+ * Turns: 1
+ * Author: Codex Agent
+ * Date: 2025-09-05T19:46:19Z
+ * Exports: PersonServiceTests
+ * Description: Unit tests verifying the reactive CRUD operations of {@link PersonService} using Reactor
+ *              utilities.
+ */
+package com.bobwares.registration;
+
+import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Validates {@link PersonService} behavior.
+ */
+public class PersonServiceTests {
+
+    /**
+     * Exercises create, update, delete lifecycle and ensures retrieval after deletion fails.
+     */
+    @Test
+    void createGetUpdateDeleteFlow() {
+        PersonService service = new PersonService();
+        PersonRequest request = new PersonRequest("John", "Doe", "Boston", "MA", "02115");
+
+        Person created = service.create(request).block();
+        assertNotNull(created);
+        assertEquals("John", created.firstName());
+
+        PersonRequest update = new PersonRequest("Jane", "Doe", "Cambridge", "MA", "02139");
+        Person updated = service.update(created.id(), update).block();
+        assertEquals("Jane", updated.firstName());
+
+        service.delete(created.id()).block();
+
+        StepVerifier.create(service.get(created.id()))
+                .expectError(PersonNotFoundException.class)
+                .verify();
+    }
+}


### PR DESCRIPTION
## Summary
- add Person domain, service, controller, and exception for async WebFlux CRUD
- generate unit and integration tests and E2E HTTP scenario
- enable springdoc OpenAPI UI and update version history

## Testing
- `./mvnw -q -DskipITs=false test` *(fails: wget failed to fetch dependencies)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3da2a960832da95839e6ca4feec5