### PR TITLE
Add Person WebFlux CRUD service with tests and OpenAPI

### DIFF
--- a/ai/agentic-pipeline/turns/1/adr.md
+++ b/ai/agentic-pipeline/turns/1/adr.md
@@ -1,0 +1,15 @@
+# Use WebFlux with In-Memory Store for Person CRUD
+
+**Status**: Accepted
+
+**Date**: 2025-09-05
+
+**Context**
+A simple asynchronous CRUD API was required for a person domain without external dependencies.
+
+**Decision**
+Implemented a Spring WebFlux service with an in-memory `ConcurrentHashMap` and exposed endpoints annotated with springdoc OpenAPI.
+
+**Consequences**
+- Positive: No external database needed; fast and asynchronous.
+- Negative: Data is volatile and not shared across instances.

--- a/ai/agentic-pipeline/turns/1/changelog.md
+++ b/ai/agentic-pipeline/turns/1/changelog.md
@@ -1,0 +1,13 @@
+# Turn: 1  – 2025-09-05 23:11:56 UTC
+
+## prompt
+
+execute task project_root/ai/agentic-pipeline/tasks/create_rest_service.task.md
+
+#### Task
+Create a complete REST service based on input parameters.
+
+#### Changes
+- Implemented Person domain, service, controller, and OpenAPI configuration.
+- Added unit and integration tests for Person endpoints.
+- Added end-to-end HTTP scenario for Person lifecycle.

--- a/ai/agentic-pipeline/turns/1/manifest.json
+++ b/ai/agentic-pipeline/turns/1/manifest.json
@@ -1,0 +1,26 @@
+{
+  "turnId": 1,
+  "timestampUtc": "2025-09-05T23:11:56Z",
+  "task": "create_rest_service",
+  "changes": {
+    "added": [
+      "src/main/java/com/bobwares/registration/Person.java",
+      "src/main/java/com/bobwares/registration/PersonRequest.java",
+      "src/main/java/com/bobwares/registration/PersonService.java",
+      "src/main/java/com/bobwares/registration/PersonNotFoundException.java",
+      "src/main/java/com/bobwares/registration/PersonController.java",
+      "src/test/java/com/bobwares/registration/PersonServiceTests.java",
+      "src/test/java/com/bobwares/registration/PersonControllerIT.java",
+      "e2e/person.http",
+      "ai/agentic-pipeline/turns/1/changelog.md",
+      "ai/agentic-pipeline/turns/1/adr.md",
+      "ai/agentic-pipeline/turns/1/manifest.json"
+    ],
+    "modified": [
+      "pom.xml",
+      "src/main/resources/application.yml",
+      "changelog.md"
+    ],
+    "deleted": []
+  }
+}

--- a/ai/agentic-pipeline/turns/index.csv
+++ b/ai/agentic-pipeline/turns/index.csv
@@ -1,0 +1,2 @@
+turnId,timestampUtc,task,branch,tag,headAfter,testsPassed,testsFailed,coverageDeltaPct
+1,2025-09-05T23:11:56Z,create_rest_service,,,pending,0,0,0

--- a/changelog.md
+++ b/changelog.md
@@ -20,3 +20,13 @@ Update metadata headers and add Makefile
 - Added metadata headers to source, test, and configuration files.
 - Introduced Makefile for build and test commands.
 - Created changelog to track version history.
+
+### 0.0.3 – 2025-09-05 23:11:56 UTC (work)
+
+#### Task
+Create Person CRUD REST service.
+
+#### Changes
+- Added person WebFlux CRUD API with OpenAPI documentation.
+- Added unit and integration tests for person endpoints.
+- Added person.e2e HTTP scenario and springdoc dependency.

--- a/e2e/person.http
+++ b/e2e/person.http
@@ -1,0 +1,47 @@
+# App: Person CRUD Service
+# Package: e2e
+# File: person.http
+# Version: 0.1.0
+# Turns: 1
+# Author: Codex Agent
+# Date: 2025-09-05T23:11:56Z
+# Exports: create, read, update, delete
+# Description: End-to-end HTTP scenario exercising Person CRUD lifecycle.
+
+@host = http://localhost:8080
+
+### Create person
+POST {{host}}/api/persons
+Content-Type: application/json
+
+{
+  "first_name": "John",
+  "last_name": "Doe",
+  "city": "Springfield",
+  "state": "IL",
+  "zip": "62704"
+}
+
+> {% client.global.set("personId", response.body.id); %}
+
+### Get person
+GET {{host}}/api/persons/{{personId}}
+
+### Update person
+PUT {{host}}/api/persons/{{personId}}
+Content-Type: application/json
+
+{
+  "first_name": "Jane",
+  "last_name": "Doe",
+  "city": "Springfield",
+  "state": "IL",
+  "zip": "62704"
+}
+
+### Delete person
+DELETE {{host}}/api/persons/{{personId}}
+
+### Verify deletion
+GET {{host}}/api/persons/{{personId}}
+

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,11 @@
             <artifactId>reactor-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webflux-ui</artifactId>
+            <version>2.5.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/bobwares/registration/Person.java
+++ b/src/main/java/com/bobwares/registration/Person.java
@@ -1,0 +1,51 @@
+/**
+ * App: Person CRUD Service
+ * Package: com.bobwares.registration
+ * File: Person.java
+ * Version: 0.1.0
+ * Turns: 1
+ * Author: Codex Agent
+ * Date: 2025-09-05T23:11:56Z
+ * Exports: Person, from, from
+ * Description: Domain record representing a person with factory methods for creation and update.
+ */
+package com.bobwares.registration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.UUID;
+
+/**
+ * Immutable person domain model.
+ */
+public record Person(
+        UUID id,
+        @JsonProperty("first_name") String firstName,
+        @JsonProperty("last_name") String lastName,
+        @JsonProperty("city") String city,
+        @JsonProperty("state") String state,
+        @JsonProperty("zip") String zip
+) {
+    /**
+     * Creates a new {@link Person} from the provided {@link PersonRequest} generating a new identifier.
+     *
+     * @param request incoming person data
+     * @return newly created person
+     */
+    public static Person from(PersonRequest request) {
+        return new Person(UUID.randomUUID(), request.firstName(), request.lastName(),
+                request.city(), request.state(), request.zip());
+    }
+
+    /**
+     * Creates a {@link Person} with the supplied identifier from the provided {@link PersonRequest}.
+     *
+     * @param id      existing identifier
+     * @param request incoming person data
+     * @return person instance with preserved identifier
+     */
+    public static Person from(UUID id, PersonRequest request) {
+        return new Person(id, request.firstName(), request.lastName(),
+                request.city(), request.state(), request.zip());
+    }
+}

--- a/src/main/java/com/bobwares/registration/PersonController.java
+++ b/src/main/java/com/bobwares/registration/PersonController.java
@@ -1,0 +1,116 @@
+/**
+ * App: Person CRUD Service
+ * Package: com.bobwares.registration
+ * File: PersonController.java
+ * Version: 0.1.0
+ * Turns: 1
+ * Author: Codex Agent
+ * Date: 2025-09-05T23:11:56Z
+ * Exports: PersonController
+ * Description: WebFlux controller exposing asynchronous CRUD endpoints for persons.
+ */
+package com.bobwares.registration;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+import java.util.UUID;
+
+/**
+ * REST controller for managing {@link Person} resources.
+ */
+@RestController
+@RequestMapping("/api/persons")
+@Validated
+@Tag(name = "Persons", description = "Asynchronous CRUD for persons")
+public class PersonController {
+    private final PersonService service;
+
+    /**
+     * Constructs the controller with required dependencies.
+     *
+     * @param service person service
+     */
+    public PersonController(PersonService service) {
+        this.service = service;
+    }
+
+    /**
+     * Creates a new person.
+     *
+     * @param request person payload
+     * @return persisted person
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "Create person", description = "Creates a new person")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Person created", content = @Content(schema = @Schema(implementation = Person.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid input", content = @Content)
+    })
+    public Mono<Person> create(@Valid @RequestBody PersonRequest request) {
+        return service.create(request);
+    }
+
+    /**
+     * Retrieves a person by identifier.
+     *
+     * @param id person identifier
+     * @return person
+     */
+    @GetMapping("/{id}")
+    @Operation(summary = "Get person", description = "Fetches a person by identifier")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Person found", content = @Content(schema = @Schema(implementation = Person.class))),
+            @ApiResponse(responseCode = "404", description = "Person not found", content = @Content)
+    })
+    public Mono<Person> get(@Parameter(description = "Person identifier") @PathVariable UUID id) {
+        return service.get(id);
+    }
+
+    /**
+     * Updates an existing person.
+     *
+     * @param id      person identifier
+     * @param request update payload
+     * @return updated person
+     */
+    @PutMapping("/{id}")
+    @Operation(summary = "Update person", description = "Updates a person by identifier")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Person updated", content = @Content(schema = @Schema(implementation = Person.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid input", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Person not found", content = @Content)
+    })
+    public Mono<Person> update(@Parameter(description = "Person identifier") @PathVariable UUID id,
+                               @Valid @RequestBody PersonRequest request) {
+        return service.update(id, request);
+    }
+
+    /**
+     * Deletes a person by identifier.
+     *
+     * @param id person identifier
+     * @return completion signal
+     */
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "Delete person", description = "Deletes a person by identifier")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Person deleted", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Person not found", content = @Content)
+    })
+    public Mono<Void> delete(@Parameter(description = "Person identifier") @PathVariable UUID id) {
+        return service.delete(id);
+    }
+}

--- a/src/main/java/com/bobwares/registration/PersonNotFoundException.java
+++ b/src/main/java/com/bobwares/registration/PersonNotFoundException.java
@@ -1,0 +1,32 @@
+/**
+ * App: Person CRUD Service
+ * Package: com.bobwares.registration
+ * File: PersonNotFoundException.java
+ * Version: 0.1.0
+ * Turns: 1
+ * Author: Codex Agent
+ * Date: 2025-09-05T23:11:56Z
+ * Exports: PersonNotFoundException
+ * Description: Exception indicating a person identifier was not found.
+ */
+package com.bobwares.registration;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.util.UUID;
+
+/**
+ * Signals that a person could not be located in the store.
+ */
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class PersonNotFoundException extends RuntimeException {
+    /**
+     * Constructs the exception with the missing identifier.
+     *
+     * @param id missing identifier
+     */
+    public PersonNotFoundException(UUID id) {
+        super("Person not found: " + id);
+    }
+}

--- a/src/main/java/com/bobwares/registration/PersonRequest.java
+++ b/src/main/java/com/bobwares/registration/PersonRequest.java
@@ -1,0 +1,29 @@
+/**
+ * App: Person CRUD Service
+ * Package: com.bobwares.registration
+ * File: PersonRequest.java
+ * Version: 0.1.0
+ * Turns: 1
+ * Author: Codex Agent
+ * Date: 2025-09-05T23:11:56Z
+ * Exports: PersonRequest
+ * Description: DTO carrying incoming person data with validation constraints.
+ */
+package com.bobwares.registration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Immutable request payload for person operations.
+ */
+public record PersonRequest(
+        @JsonProperty("first_name") @NotBlank String firstName,
+        @JsonProperty("last_name") @NotBlank String lastName,
+        @JsonProperty("city") @NotBlank String city,
+        @JsonProperty("state") @NotBlank @Size(min = 2, max = 2) String state,
+        @JsonProperty("zip") @NotBlank @Pattern(regexp = "^[0-9]{5}(-[0-9]{4})?$") String zip
+) {
+}

--- a/src/main/java/com/bobwares/registration/PersonService.java
+++ b/src/main/java/com/bobwares/registration/PersonService.java
@@ -1,0 +1,75 @@
+/**
+ * App: Person CRUD Service
+ * Package: com.bobwares.registration
+ * File: PersonService.java
+ * Version: 0.1.0
+ * Turns: 1
+ * Author: Codex Agent
+ * Date: 2025-09-05T23:11:56Z
+ * Exports: PersonService
+ * Description: Service providing asynchronous CRUD operations backed by an in-memory store.
+ */
+package com.bobwares.registration;
+
+import reactor.core.publisher.Mono;
+
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * In-memory service managing {@link Person} instances.
+ */
+public class PersonService {
+    private final ConcurrentMap<UUID, Person> store = new ConcurrentHashMap<>();
+
+    /**
+     * Persists a new person constructed from the request.
+     *
+     * @param request incoming person data
+     * @return saved person
+     */
+    public Mono<Person> create(PersonRequest request) {
+        Person person = Person.from(request);
+        store.put(person.id(), person);
+        return Mono.just(person);
+    }
+
+    /**
+     * Retrieves a person by identifier.
+     *
+     * @param id unique identifier
+     * @return person mono or error when not found
+     */
+    public Mono<Person> get(UUID id) {
+        Person person = store.get(id);
+        return person != null ? Mono.just(person) : Mono.error(new PersonNotFoundException(id));
+    }
+
+    /**
+     * Updates an existing person using request data.
+     *
+     * @param id      existing identifier
+     * @param request incoming person data
+     * @return updated person or error when not found
+     */
+    public Mono<Person> update(UUID id, PersonRequest request) {
+        if (!store.containsKey(id)) {
+            return Mono.error(new PersonNotFoundException(id));
+        }
+        Person updated = Person.from(id, request);
+        store.put(id, updated);
+        return Mono.just(updated);
+    }
+
+    /**
+     * Deletes a person by identifier.
+     *
+     * @param id unique identifier
+     * @return completion signal or error when not found
+     */
+    public Mono<Void> delete(UUID id) {
+        Person removed = store.remove(id);
+        return removed != null ? Mono.empty() : Mono.error(new PersonNotFoundException(id));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,12 +1,13 @@
-# App: common
+# App: Person CRUD Service
 # Package: configuration
 # File: application.yml
-# Version: 0.1.0
-# Author: AI
-# Date: 2025-09-04T22:11:01Z
+# Version: 0.1.1
+# Turns: 1
+# Author: Codex Agent
+# Date: 2025-09-05T23:11:56Z
 # Exports: spring.application.name
 # Description: Configures the Spring Boot application name.
 
 spring:
   application:
-    name: common
+    name: person-crud-service

--- a/src/test/java/com/bobwares/registration/PersonControllerIT.java
+++ b/src/test/java/com/bobwares/registration/PersonControllerIT.java
@@ -1,0 +1,80 @@
+/**
+ * App: Person CRUD Service
+ * Package: com.bobwares.registration
+ * File: PersonControllerIT.java
+ * Version: 0.1.0
+ * Turns: 1
+ * Author: Codex Agent
+ * Date: 2025-09-05T23:11:56Z
+ * Exports: PersonControllerIT
+ * Description: Integration tests for PersonController verifying HTTP endpoints.
+ */
+package com.bobwares.registration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.is;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+/**
+ * Integration tests using {@link WebTestClient}.
+ */
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+class PersonControllerIT {
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    WebTestClient client;
+
+    @Test
+    void lifecycle() {
+        PersonRequest req = new PersonRequest("John", "Doe", "Springfield", "IL", "62704");
+
+        UUID id = client.post().uri("/api/persons")
+                .bodyValue(req)
+                .exchange()
+                .expectStatus().isCreated()
+                .expectBody(Person.class)
+                .returnResult().getResponseBody().id();
+
+        client.get().uri("/api/persons/{id}", id)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.first_name", is("John"));
+
+        PersonRequest updateReq = new PersonRequest("Jane", "Doe", "Springfield", "IL", "62704");
+        client.put().uri("/api/persons/{id}", id)
+                .bodyValue(updateReq)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.first_name", is("Jane"));
+
+        client.delete().uri("/api/persons/{id}", id)
+                .exchange()
+                .expectStatus().isNoContent();
+
+        client.get().uri("/api/persons/{id}", id)
+                .exchange()
+                .expectStatus().isNotFound();
+    }
+
+    @Test
+    void validation() {
+        PersonRequest bad = new PersonRequest("", "", "", "I", "123");
+
+        client.post().uri("/api/persons")
+                .bodyValue(bad)
+                .exchange()
+                .expectStatus().isBadRequest();
+    }
+}

--- a/src/test/java/com/bobwares/registration/PersonServiceTests.java
+++ b/src/test/java/com/bobwares/registration/PersonServiceTests.java
@@ -1,0 +1,45 @@
+/**
+ * App: Person CRUD Service
+ * Package: com.bobwares.registration
+ * File: PersonServiceTests.java
+ * Version: 0.1.0
+ * Turns: 1
+ * Author: Codex Agent
+ * Date: 2025-09-05T23:11:56Z
+ * Exports: PersonServiceTests
+ * Description: Unit tests validating PersonService create, get, update, and delete operations.
+ */
+package com.bobwares.registration;
+
+import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link PersonService}.
+ */
+class PersonServiceTests {
+
+    @Test
+    void createGetUpdateDeleteFlow() {
+        PersonService service = new PersonService();
+        PersonRequest req = new PersonRequest("John", "Doe", "Springfield", "IL", "62704");
+
+        Person created = service.create(req).block();
+        assertNotNull(created);
+        assertNotNull(created.id());
+
+        Person fetched = service.get(created.id()).block();
+        assertEquals("John", fetched.firstName());
+
+        PersonRequest updateReq = new PersonRequest("Jane", "Doe", "Springfield", "IL", "62704");
+        Person updated = service.update(created.id(), updateReq).block();
+        assertEquals("Jane", updated.firstName());
+
+        service.delete(created.id()).block();
+        StepVerifier.create(service.get(created.id()))
+                .expectError(PersonNotFoundException.class)
+                .verify();
+    }
+}


### PR DESCRIPTION
## Summary
- implement Person domain model, in-memory service, and WebFlux controller with OpenAPI annotations
- add unit and integration tests plus end-to-end HTTP scenario
- configure springdoc and update application name

## Testing
- `mvn -q -DskipITs=false test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6dc107b0832dbba92c8dab63788a