### PR TITLE
Add Person table migration and entity spec

### DIFF
--- a/ai/agentic-pipeline/turns/2/adr.md
+++ b/ai/agentic-pipeline/turns/2/adr.md
@@ -1,0 +1,15 @@
+# ADR 2: Person Table Schema and Test Data
+
+Status: Accepted
+Date: 2025-09-07
+
+## Context
+We needed to persist person records based on existing JSON request schema.
+
+## Decision
+Create a single `person` table with columns for first name, last name, city, state, and zip. Provide idempotent test data script for development.
+
+## Consequences
+- Positive: Prepares project for database persistence.
+- Negative: Lacks additional normalization for addresses; may need future enhancement.
+- Follow-up: Add indexes and related tables as domain grows.

--- a/ai/agentic-pipeline/turns/2/changelog.md
+++ b/ai/agentic-pipeline/turns/2/changelog.md
@@ -1,0 +1,18 @@
+# Turn 2 — Changelog
+Date (UTC): 2025-09-07 01:22:38
+Task: create-sql-dll-from-schema
+
+## Summary
+Generated Person SQL migration, entity specification, and test data.
+
+## Changes
+- Added SQL migration for Person table.
+- Generated JSON entity spec from migration.
+- Added sample test data script.
+
+## SemVer Impact
+- Patch: adds database artifacts without API changes.
+
+## Linked Artifacts
+- ADR: ./adr.md
+- Manifest: ./manifest.json

--- a/ai/agentic-pipeline/turns/2/manifest.json
+++ b/ai/agentic-pipeline/turns/2/manifest.json
@@ -1,0 +1,21 @@
+{
+  "turnId": 2,
+  "timestampUtc": "2025-09-07T01:22:38Z",
+  "task": "create-sql-dll-from-schema",
+  "changes": {
+    "added": [
+      "db/migrations/01_person.sql",
+      "db/entity-specs/person-entities.json",
+      "db/scripts/person_test_data.sql",
+      "ai/agentic-pipeline/turns/2/changelog.md",
+      "ai/agentic-pipeline/turns/2/adr.md",
+      "ai/agentic-pipeline/turns/2/manifest.json",
+      "ai/agentic-pipeline/turns/2/prompt-turn-2.md"
+    ],
+    "modified": [
+      "changelog.md",
+      "turns/index.csv"
+    ],
+    "deleted": []
+  }
+}

--- a/ai/agentic-pipeline/turns/2/prompt-turn-2.md
+++ b/ai/agentic-pipeline/turns/2/prompt-turn-2.md
@@ -1,0 +1,7 @@
+execute task project_root/ai/agentic-pipeline/tasks/create_sql_dll_from_schema.task.md
+
+Inputs
+- API Request Schema: project_root/schemas/person.schema.json
+- Package root: com.bobwares.registration
+- Project name: Person CRUD Service
+- Version seed: 0.1.0

--- a/changelog.md
+++ b/changelog.md
@@ -30,3 +30,13 @@ Add Person CRUD service
 - Implement asynchronous Person CRUD API with WebFlux and OpenAPI.
 - Add unit and integration tests for Person service and controller.
 - Provide end-to-end HTTP scenario for Person lifecycle.
+
+### 0.0.4 – 2025-09-07 01:22:38 UTC (work)
+
+#### Task
+Generate normalized Person tables and test data
+
+#### Changes
+- Add SQL migration for Person table.
+- Generate JSON entity spec from migration.
+- Add test data script for Person.

--- a/db/entity-specs/person-entities.json
+++ b/db/entity-specs/person-entities.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "<repo-root>/entity-specs/person-entities.json",
+  "title": "person Domain Entities",
+  "type": "object",
+  "x-db": { "schema": "person" },
+  "definitions": {
+    "Person": {
+      "type": "object",
+      "properties": {
+        "person_id": { "type": "integer" },
+        "first_name": { "type": "string", "maxLength": 255 },
+        "last_name": { "type": "string", "maxLength": 255 },
+        "city": { "type": "string", "maxLength": 255 },
+        "state": { "type": "string", "minLength": 2, "maxLength": 2 },
+        "zip": { "type": "string", "maxLength": 10 }
+      },
+      "required": ["person_id", "first_name", "last_name", "city", "state", "zip"],
+      "x-db": {
+        "primaryKey": ["person_id"],
+        "foreignKey": [],
+        "unique": [],
+        "indexes": []
+      }
+    }
+  }
+}

--- a/db/migrations/01_person.sql
+++ b/db/migrations/01_person.sql
@@ -1,0 +1,22 @@
+-- App: Person CRUD Service
+-- Package: com.bobwares.registration
+-- File: 01_person.sql
+-- Version: 0.1.0
+-- Turns: 2
+-- Author: Codex
+-- Date: 2025-09-07T01:22:38Z
+-- Exports: person table
+-- Description: Creates normalized table for storing person records.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS person (
+    person_id   SERIAL PRIMARY KEY,
+    first_name  VARCHAR(255) NOT NULL,
+    last_name   VARCHAR(255) NOT NULL,
+    city        VARCHAR(255) NOT NULL,
+    state       CHAR(2) NOT NULL,
+    zip         VARCHAR(10) NOT NULL
+);
+
+COMMIT;

--- a/db/scripts/person_test_data.sql
+++ b/db/scripts/person_test_data.sql
@@ -1,0 +1,29 @@
+-- App: Person CRUD Service
+-- Package: com.bobwares.registration
+-- File: person_test_data.sql
+-- Version: 0.1.0
+-- Turns: 2
+-- Author: Codex
+-- Date: 2025-09-07T01:22:38Z
+-- Exports: sample person records
+-- Description: Inserts sample person records for development testing.
+
+BEGIN;
+
+INSERT INTO person (person_id, first_name, last_name, city, state, zip) VALUES
+    (1,'Alice','Smith','Springfield','IL','62701'),
+    (2,'Bob','Johnson','Madison','WI','53703'),
+    (3,'Carol','Williams','Austin','TX','73301'),
+    (4,'David','Brown','Denver','CO','80014'),
+    (5,'Eva','Jones','Phoenix','AZ','85001'),
+    (6,'Frank','Miller','Portland','OR','97201'),
+    (7,'Grace','Davis','Boston','MA','02108'),
+    (8,'Hank','Wilson','Seattle','WA','98101'),
+    (9,'Ivy','Moore','Atlanta','GA','30303'),
+    (10,'Jack','Taylor','Miami','FL','33101')
+ON CONFLICT DO NOTHING;
+
+-- smoke test
+SELECT COUNT(*) FROM person;
+
+COMMIT;

--- a/turns/index.csv
+++ b/turns/index.csv
@@ -1,2 +1,3 @@
 turnId,timestampUtc,task,branch,tag
 1,2025-09-06T02:28:22Z,create-rest-service,work,
+2,2025-09-07T01:22:38Z,create-sql-dll-from-schema,work,


### PR DESCRIPTION
## Summary
- add SQL migration for `person` table
- derive JSON entity spec from migration
- provide sample test data script

## Testing
- `npx --yes ajv-cli compile -s db/entity-specs/person-entities.json --spec=draft2020 --strict=false`
- `./mvnw -q -e test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bcddd2e27c832dbecab0e601556410