### PR TITLE
Add Customer profile SQL migration and test data

### DIFF
--- a/ai/agentic-pipeline/turns/2/adr.md
+++ b/ai/agentic-pipeline/turns/2/adr.md
@@ -1,0 +1,15 @@
+# ADR 2: Normalize CustomerProfile JSON schema into PostgreSQL
+
+Status: Accepted
+Date: 2025-09-07
+
+## Context
+The system needs a relational schema for customer profiles based on the provided JSON schema. Tables must be normalized and include indexes and a flattened view for queries.
+
+## Decision
+Create separate tables for postal addresses, privacy settings, emails, and phone numbers. The root customer table references these tables and a view aggregates related data for read operations.
+
+## Consequences
+- Positive: Reduces duplication and supports flexible querying.
+- Negative: Requires joins and seed data across multiple tables.
+- Follow-up: Implement migration execution automation in future turns.

--- a/ai/agentic-pipeline/turns/2/changelog.md
+++ b/ai/agentic-pipeline/turns/2/changelog.md
@@ -1,0 +1,18 @@
+# Turn 2 — Changelog
+Date (UTC): 2025-09-07 15:17:14
+Task: create_sql_dll_from_schema
+
+## Summary
+Generated PostgreSQL migration and test data for the CustomerProfile schema and documented execution steps.
+
+## Changes
+- Added normalized SQL migration and view for customer profile.
+- Seeded customer test data with addresses, privacy settings, emails, and phone numbers.
+- Documented migration and seeding in db/README.md.
+
+## SemVer Impact
+- Minor: adds database schema and test data for customer profile.
+
+## Linked Artifacts
+- ADR: ./adr.md
+- Manifest: ./manifest.json

--- a/ai/agentic-pipeline/turns/2/manifest.json
+++ b/ai/agentic-pipeline/turns/2/manifest.json
@@ -1,0 +1,20 @@
+{
+  "turnId": 2,
+  "timestampUtc": "2025-09-07T15:17:22Z",
+  "task": "create_sql_dll_from_schema",
+  "changes": {
+    "added": [
+      "db/README.md",
+      "db/migrations/01_customer_profile_tables.sql",
+      "db/scripts/customer_test_data.sql",
+      "ai/agentic-pipeline/turns/2/changelog.md",
+      "ai/agentic-pipeline/turns/2/adr.md",
+      "ai/agentic-pipeline/turns/2/manifest.json"
+    ],
+    "modified": [
+      "changelog.md",
+      "turns/index.csv"
+    ],
+    "deleted": []
+  }
+}

--- a/changelog.md
+++ b/changelog.md
@@ -30,3 +30,13 @@ Add Person CRUD service
 - Implement asynchronous Person CRUD API with WebFlux and OpenAPI.
 - Add unit and integration tests for Person service and controller.
 - Provide end-to-end HTTP scenario for Person lifecycle.
+
+### 0.0.4 – 2025-09-07 15:17:30 UTC (work)
+
+#### Task
+Generate SQL DDL and test data for Customer schema
+
+#### Changes
+- Added normalized PostgreSQL migration and view for customer profile.
+- Seeded sample customer data with addresses, privacy settings, emails, and phone numbers.
+- Documented migration execution in db/README.md.

--- a/db/README.md
+++ b/db/README.md
@@ -1,0 +1,30 @@
+<!--
+App: Customer Profile CRUD Service
+Package: db
+File: README.md
+Version: 0.1.0
+Turns: 2
+Author: AI Agent
+Date: 2025-09-07T15:16:44Z
+Exports: Documentation
+Description: Instructions for running migrations and loading test data for the customer profile database schema.
+-->
+
+# Database Migrations
+
+## Domain Migration
+
+To initialize the customer profile schema and seed test data locally:
+
+```bash
+# Apply migrations
+psql -f db/migrations/01_customer_profile_tables.sql
+
+# Load test data
+psql -f db/scripts/customer_test_data.sql
+
+# Smoke test
+psql -c "SELECT COUNT(*) FROM customer;"
+```
+
+Ensure PostgreSQL 16 is running and accessible via `psql` before executing the scripts.

--- a/db/migrations/01_customer_profile_tables.sql
+++ b/db/migrations/01_customer_profile_tables.sql
@@ -1,0 +1,88 @@
+/*
+ * App: Customer Profile CRUD Service
+ * Package: db
+ * File: 01_customer_profile_tables.sql
+ * Version: 0.1.0
+ * Turns: 2
+ * Author: AI Agent
+ * Date: 2025-09-07T15:16:48Z
+ * Exports: tables postal_address, privacy_settings, customer, customer_email, customer_phone_number; view customer_profile_view
+ * Description: Creates normalized PostgreSQL tables and view for customer profiles.
+ */
+
+BEGIN;
+
+CREATE SCHEMA IF NOT EXISTS customer_profile;
+SET search_path TO customer_profile, public;
+
+/* Reference tables */
+CREATE TABLE IF NOT EXISTS postal_address (
+    address_id SERIAL PRIMARY KEY,
+    line1 VARCHAR(255) NOT NULL,
+    line2 VARCHAR(255),
+    city VARCHAR(100) NOT NULL,
+    state VARCHAR(50) NOT NULL,
+    postal_code VARCHAR(20),
+    country CHAR(2) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS privacy_settings (
+    privacy_settings_id SERIAL PRIMARY KEY,
+    marketing_emails_enabled BOOLEAN NOT NULL,
+    two_factor_enabled BOOLEAN NOT NULL
+);
+
+/* Root entity */
+CREATE TABLE IF NOT EXISTS customer (
+    customer_id UUID PRIMARY KEY,
+    first_name VARCHAR(255) NOT NULL,
+    middle_name VARCHAR(255),
+    last_name VARCHAR(255) NOT NULL,
+    address_id INT REFERENCES postal_address(address_id),
+    privacy_settings_id INT REFERENCES privacy_settings(privacy_settings_id)
+);
+CREATE INDEX IF NOT EXISTS idx_customer_address_id ON customer (address_id);
+CREATE INDEX IF NOT EXISTS idx_customer_privacy_settings_id ON customer (privacy_settings_id);
+
+/* Collections */
+CREATE TABLE IF NOT EXISTS customer_email (
+    email_id SERIAL PRIMARY KEY,
+    customer_id UUID NOT NULL REFERENCES customer(customer_id) ON DELETE CASCADE,
+    email VARCHAR(255) NOT NULL,
+    UNIQUE (customer_id, email)
+);
+CREATE INDEX IF NOT EXISTS idx_customer_email_customer_id ON customer_email (customer_id);
+
+CREATE TABLE IF NOT EXISTS customer_phone_number (
+    phone_id SERIAL PRIMARY KEY,
+    customer_id UUID NOT NULL REFERENCES customer(customer_id) ON DELETE CASCADE,
+    type VARCHAR(20) NOT NULL,
+    number VARCHAR(15) NOT NULL,
+    UNIQUE (customer_id, number)
+);
+CREATE INDEX IF NOT EXISTS idx_customer_phone_customer_id ON customer_phone_number (customer_id);
+
+/* Flattened view */
+CREATE OR REPLACE VIEW customer_profile_view AS
+SELECT c.customer_id,
+       c.first_name,
+       c.middle_name,
+       c.last_name,
+       a.line1,
+       a.line2,
+       a.city,
+       a.state,
+       a.postal_code,
+       a.country,
+       ps.marketing_emails_enabled,
+       ps.two_factor_enabled,
+       COALESCE(array_agg(DISTINCT e.email) FILTER (WHERE e.email IS NOT NULL), '{}') AS emails,
+       COALESCE(json_agg(json_build_object('type', pn.type, 'number', pn.number)) FILTER (WHERE pn.phone_id IS NOT NULL), '[]') AS phone_numbers
+FROM customer c
+LEFT JOIN postal_address a ON c.address_id = a.address_id
+LEFT JOIN privacy_settings ps ON c.privacy_settings_id = ps.privacy_settings_id
+LEFT JOIN customer_email e ON c.customer_id = e.customer_id
+LEFT JOIN customer_phone_number pn ON c.customer_id = pn.customer_id
+GROUP BY c.customer_id, a.address_id, ps.privacy_settings_id;
+
+COMMIT;

--- a/db/scripts/customer_test_data.sql
+++ b/db/scripts/customer_test_data.sql
@@ -1,0 +1,93 @@
+/*
+ * App: Customer Profile CRUD Service
+ * Package: db
+ * File: customer_test_data.sql
+ * Version: 0.1.0
+ * Turns: 2
+ * Author: AI Agent
+ * Date: 2025-09-07T15:17:00Z
+ * Exports: sample customer domain records
+ * Description: Idempotent seed data for customer profiles with emails and phone numbers.
+ */
+
+BEGIN;
+
+-- Insert postal addresses
+INSERT INTO postal_address (address_id, line1, line2, city, state, postal_code, country)
+VALUES
+    (1, '100 Market St', NULL, 'Springfield', 'IL', '62701', 'US'),
+    (2, '200 Oak Ave', 'Apt 2', 'Madison', 'WI', '53703', 'US'),
+    (3, '300 Pine Rd', NULL, 'Austin', 'TX', '73301', 'US'),
+    (4, '400 Maple Ln', NULL, 'Denver', 'CO', '80014', 'US'),
+    (5, '500 Cedar Blvd', 'Suite 5', 'Phoenix', 'AZ', '85001', 'US'),
+    (6, '600 Birch Way', NULL, 'Portland', 'OR', '97035', 'US'),
+    (7, '700 Walnut St', NULL, 'Boston', 'MA', '02108', 'US'),
+    (8, '800 Chestnut Dr', NULL, 'Seattle', 'WA', '98101', 'US'),
+    (9, '900 Elm Cir', NULL, 'Atlanta', 'GA', '30303', 'US'),
+    (10, '1000 Ash Pl', NULL, 'Miami', 'FL', '33101', 'US')
+ON CONFLICT DO NOTHING;
+
+-- Insert privacy settings
+INSERT INTO privacy_settings (privacy_settings_id, marketing_emails_enabled, two_factor_enabled)
+VALUES
+    (1, TRUE, FALSE),
+    (2, FALSE, TRUE),
+    (3, TRUE, TRUE),
+    (4, FALSE, FALSE),
+    (5, TRUE, FALSE),
+    (6, FALSE, TRUE),
+    (7, TRUE, TRUE),
+    (8, FALSE, FALSE),
+    (9, TRUE, FALSE),
+    (10, FALSE, TRUE)
+ON CONFLICT DO NOTHING;
+
+-- Insert customers
+INSERT INTO customer (customer_id, first_name, middle_name, last_name, address_id, privacy_settings_id)
+VALUES
+    ('11111111-1111-1111-1111-111111111111', 'Alice', NULL, 'Smith', 1, 1),
+    ('22222222-2222-2222-2222-222222222222', 'Bob', 'J', 'Jones', 2, 2),
+    ('33333333-3333-3333-3333-333333333333', 'Charlie', NULL, 'Brown', 3, 3),
+    ('44444444-4444-4444-4444-444444444444', 'David', 'K', 'Miller', 4, 4),
+    ('55555555-5555-5555-5555-555555555555', 'Emma', NULL, 'Davis', 5, 5),
+    ('66666666-6666-6666-6666-666666666666', 'Frank', NULL, 'Wilson', 6, 6),
+    ('77777777-7777-7777-7777-777777777777', 'Grace', 'L', 'Taylor', 7, 7),
+    ('88888888-8888-8888-8888-888888888888', 'Hugo', NULL, 'Anderson', 8, 8),
+    ('99999999-9999-9999-9999-999999999999', 'Isabel', NULL, 'Thomas', 9, 9),
+    ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'Jack', 'M', 'Jackson', 10, 10)
+ON CONFLICT DO NOTHING;
+
+-- Insert customer emails
+INSERT INTO customer_email (customer_id, email)
+VALUES
+    ('11111111-1111-1111-1111-111111111111', 'alice@example.com'),
+    ('22222222-2222-2222-2222-222222222222', 'bob@example.com'),
+    ('33333333-3333-3333-3333-333333333333', 'charlie@example.com'),
+    ('44444444-4444-4444-4444-444444444444', 'david@example.com'),
+    ('55555555-5555-5555-5555-555555555555', 'emma@example.com'),
+    ('66666666-6666-6666-6666-666666666666', 'frank@example.com'),
+    ('77777777-7777-7777-7777-777777777777', 'grace@example.com'),
+    ('88888888-8888-8888-8888-888888888888', 'hugo@example.com'),
+    ('99999999-9999-9999-9999-999999999999', 'isabel@example.com'),
+    ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'jack@example.com')
+ON CONFLICT DO NOTHING;
+
+-- Insert phone numbers
+INSERT INTO customer_phone_number (customer_id, type, number)
+VALUES
+    ('11111111-1111-1111-1111-111111111111', 'mobile', '+15555550101'),
+    ('22222222-2222-2222-2222-222222222222', 'mobile', '+15555550102'),
+    ('33333333-3333-3333-3333-333333333333', 'mobile', '+15555550103'),
+    ('44444444-4444-4444-4444-444444444444', 'mobile', '+15555550104'),
+    ('55555555-5555-5555-5555-555555555555', 'mobile', '+15555550105'),
+    ('66666666-6666-6666-6666-666666666666', 'mobile', '+15555550106'),
+    ('77777777-7777-7777-7777-777777777777', 'mobile', '+15555550107'),
+    ('88888888-8888-8888-8888-888888888888', 'mobile', '+15555550108'),
+    ('99999999-9999-9999-9999-999999999999', 'mobile', '+15555550109'),
+    ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'mobile', '+15555550110')
+ON CONFLICT DO NOTHING;
+
+-- Smoke test
+SELECT COUNT(*) FROM customer;
+
+COMMIT;

--- a/turns/index.csv
+++ b/turns/index.csv
@@ -1,2 +1,3 @@
 turnId,timestampUtc,task,branch,tag
 1,2025-09-06T02:28:22Z,create-rest-service,work,
+2,2025-09-07T15:17:26Z,create_sql_dll_from_schema,work,


### PR DESCRIPTION
## Summary
- add normalized PostgreSQL migration and view for CustomerProfile schema
- seed customer test data and document migration execution

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bda125725c832d8901e6d3297062dc