### PR TITLE
Configure Postgres and env-driven Spring profiles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# App: Customer Registration Service
+# Package: infrastructure
+# File: .env.example
+# Version: 0.1.0
+# Turns: 2
+# Author: AI
+# Date: 2025-09-08T05:07:24Z
+# Exports: APP_PORT, COMPOSE_PROJECT_NAME, DB_HOST, DB_PORT, DB_NAME, DB_USERNAME, DB_PASSWORD
+# Description: Example environment variables for local development.
+
+# App
+APP_PORT=8080
+COMPOSE_PROJECT_NAME=customer-registration-service
+
+# Database
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=app
+DB_USERNAME=admin
+DB_PASSWORD=abc123

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,14 @@
+# App: Customer Registration Service
+# Package: infrastructure
+# File: .gitignore
+# Version: 0.1.1
+# Turns: 2
+# Author: AI
+# Date: 2025-09-08T05:07:24Z
+# Exports: .gitignore rules
+# Description: Specifies intentionally untracked files.
+
+.env
 .DS_Store
 /ai/output
 HELP.md

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Customer Registration Service
+
+## Local DB via Docker
+cp .env.example .env
+docker compose up -d postgres
+
+## Running with Local Profile and .env
+cp .env.example .env
+export $(grep -v '^#' .env | xargs) && mvn spring-boot:run -Dspring-boot.run.profiles=local
+# If using Docker Compose for the app container, Compose will inject env automatically.

--- a/ai/agentic-pipeline/turns/2/adr.md
+++ b/ai/agentic-pipeline/turns/2/adr.md
@@ -1,0 +1,14 @@
+# Configure Postgres with Docker and env profiles
+
+**Status**: Accepted
+
+**Date**: 2025-09-08
+
+**Context**
+Local development requires a reproducible Postgres instance and Spring to source credentials from environment variables.
+
+**Decision**
+Use Docker Compose to run Postgres 16 and load credentials from a `.env` file. Update Spring configuration and Maven dependencies accordingly.
+
+**Consequences**
+Provides consistent local database setup and enables Testcontainers for integration tests, at the cost of additional configuration files.

--- a/ai/agentic-pipeline/turns/2/changelog.md
+++ b/ai/agentic-pipeline/turns/2/changelog.md
@@ -1,0 +1,12 @@
+# Turn: 2 – 2025-09-08 05:07:24 UTC
+
+## prompt
+execute task project_root/ai/agentic-pipeline/tasks/postgres.task.md
+
+#### Task
+Configure PostgreSQL environment and Spring profiles
+
+#### Changes
+- Added Docker Compose Postgres service and .env example.
+- Configured Spring Boot datasource and profiles.
+- Updated Maven build for Testcontainers.

--- a/ai/agentic-pipeline/turns/2/manifest.json
+++ b/ai/agentic-pipeline/turns/2/manifest.json
@@ -1,0 +1,25 @@
+{
+  "turnId": 2,
+  "timestampUtc": "2025-09-08T05:07:24Z",
+  "task": "postgres-environment",
+  "changes": {
+    "added": [
+      ".env.example",
+      "README.md",
+      "ai/agentic-pipeline/turns/2/changelog.md",
+      "ai/agentic-pipeline/turns/2/adr.md",
+      "ai/agentic-pipeline/turns/2/manifest.json",
+      "src/main/resources/application-local.yml",
+      "src/test/resources/application-test.yml"
+    ],
+    "modified": [
+      ".gitignore",
+      "changelog.md",
+      "docker-compose.yml",
+      "pom.xml",
+      "src/main/resources/application.yml",
+      "turns/index.csv"
+    ],
+    "deleted": []
+  }
+}

--- a/changelog.md
+++ b/changelog.md
@@ -30,3 +30,14 @@ Add Person CRUD service
 - Implement asynchronous Person CRUD API with WebFlux and OpenAPI.
 - Add unit and integration tests for Person service and controller.
 - Provide end-to-end HTTP scenario for Person lifecycle.
+
+### 0.0.4 – 2025-09-08 05:07:24 UTC (work)
+
+#### Task
+Configure PostgreSQL environment and Spring profiles
+
+#### Changes
+- Add Docker Compose Postgres service and .env example.
+- Configure Spring Boot datasource and profiles.
+- Update Maven build for Testcontainers.
+- Document local database usage.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,31 @@
+####################################################################################################
+# App: Customer Registration Service
+# Package: infrastructure
+# File: docker-compose.yml
+# Version: 0.1.1
+# Turns: 2
+# Author: AI
+# Date: 2025-09-08T05:07:24Z
+# Exports: postgres service, app service
+# Description: Orchestrates local Postgres and application containers.
+####################################################################################################
+
 version: "3.9"
 
 services:
   postgres:
     image: postgres:16
-    container_name: ${COMPOSE_PROJECT_NAME:-my-spring-app}-postgres
+    container_name: ${COMPOSE_PROJECT_NAME:-customer-registration-service}-postgres
     environment:
-      POSTGRES_DB: ${DB_NAME:-mydb}
-      POSTGRES_USER: ${DB_USERNAME:-myuser}
-      POSTGRES_PASSWORD: ${DB_PASSWORD:-secret}
+      POSTGRES_DB: ${DB_NAME:-app}
+      POSTGRES_USER: ${DB_USERNAME:-admin}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-abc123}
     ports:
       - "${DB_PORT:-5432}:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${DB_USERNAME:-myuser} -d ${DB_NAME:-mydb}"]
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USERNAME:-admin} -d ${DB_NAME:-app}"]
       interval: 10s
       timeout: 5s
       retries: 10
@@ -22,16 +34,16 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: ${COMPOSE_PROJECT_NAME:-my-spring-app}-app
+    container_name: ${COMPOSE_PROJECT_NAME:-customer-registration-service}-app
     depends_on:
       postgres:
         condition: service_healthy
     environment:
       DB_HOST: postgres
       DB_PORT: 5432
-      DB_NAME: ${DB_NAME:-mydb}
-      DB_USERNAME: ${DB_USERNAME:-myuser}
-      DB_PASSWORD: ${DB_PASSWORD:-secret}
+      DB_NAME: ${DB_NAME:-app}
+      DB_USERNAME: ${DB_USERNAME:-admin}
+      DB_PASSWORD: ${DB_PASSWORD:-abc123}
       SPRING_PROFILES_ACTIVE: local
     ports:
       - "${APP_PORT:-8080}:8080"

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
     </scm>
     <properties>
         <java.version>21</java.version>
+        <spring.boot.version>3.5.5</spring.boot.version>
     </properties>
     <dependencies>
         <dependency>
@@ -62,6 +63,11 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
             <scope>test</scope>
         </dependency>
@@ -88,7 +94,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
                 <configuration>
+                    <release>21</release>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.projectlombok</groupId>
@@ -100,6 +108,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
                 <configuration>
                     <excludes>
                         <exclude>

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,16 @@
+####################################################################################################
+# App: Customer Registration Service
+# Package: configuration
+# File: application-local.yml
+# Version: 0.1.0
+# Turns: 2
+# Author: AI
+# Date: 2025-09-08T05:07:24Z
+# Exports: spring.datasource.username, spring.datasource.password
+# Description: Local profile overrides using environment variables for DB credentials.
+####################################################################################################
+
+spring:
+  datasource:
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,12 +1,32 @@
-# App: common
+####################################################################################################
+# App: Customer Registration Service
 # Package: configuration
 # File: application.yml
-# Version: 0.1.0
+# Version: 0.1.1
+# Turns: 2
 # Author: AI
-# Date: 2025-09-04T22:11:01Z
-# Exports: spring.application.name
-# Description: Configures the Spring Boot application name.
+# Date: 2025-09-08T05:07:24Z
+# Exports: spring.application.name, spring.datasource.url, spring.jpa.hibernate.ddl-auto, logging.level.root
+# Description: Base application configuration with Postgres datasource and logging settings.
+####################################################################################################
 
 spring:
   application:
-    name: common
+    name: ${COMPOSE_PROJECT_NAME:${project_name:customer-registration-service}}
+
+  datasource:
+    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:app}
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: true
+    show-sql: true
+
+logging:
+  level:
+    root: INFO

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,16 @@
+####################################################################################################
+# App: Customer Registration Service
+# Package: configuration
+# File: application-test.yml
+# Version: 0.1.0
+# Turns: 2
+# Author: AI
+# Date: 2025-09-08T05:07:24Z
+# Exports: spring.jpa.hibernate.ddl-auto
+# Description: Test profile settings.
+####################################################################################################
+
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: update

--- a/turns/index.csv
+++ b/turns/index.csv
@@ -1,2 +1,3 @@
 turnId,timestampUtc,task,branch,tag
 1,2025-09-06T02:28:22Z,create-rest-service,work,
+2,2025-09-08T05:07:24Z,postgres-environment,work,


### PR DESCRIPTION
## Summary
- add Docker Compose Postgres service and sample `.env` file
- configure Spring Boot profiles for datasource credentials and logging
- update Maven build with Testcontainers and Java 21 compiler settings

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68be63fdfee0832d8d89591e06c8b4fa